### PR TITLE
Add Multi-Slugcat color config

### DIFF
--- a/Menu/ArenaLobbyMenu2.cs
+++ b/Menu/ArenaLobbyMenu2.cs
@@ -30,7 +30,7 @@ public class ArenaLobbyMenu2 : SmartMenu, SelectOneButton.SelectOneButtonOwner
     public EventfulSelectOneButton[] slugcatSelectButtons;
     public TabContainer tabContainer;
     public PlayerDisplayer? playerDisplayer;
-    public ColorSlugcatDialog? colorSlugcatDialog;
+    public ColorMultipleSlugcatsDialog? colorSlugcatDialog;
     public MenuIllustration competitiveTitle, competitiveShadow;
     public MenuScene.SceneID slugcatScene;
     public string? painCatName;
@@ -460,10 +460,8 @@ public class ArenaLobbyMenu2 : SmartMenu, SelectOneButton.SelectOneButtonOwner
     }
     public void OpenColorConfig(SlugcatStats.Name? slugcat)
     {
-        if (slugcat == null) return;
-
         PlaySound(SoundID.MENU_Checkbox_Check);
-        colorSlugcatDialog = new ColorSlugcatDialog(manager, slugcat, () => { });
+        colorSlugcatDialog = new(manager, () => { }, allSlugcats, slugcat);
         manager.ShowDialog(colorSlugcatDialog);
     }
 

--- a/Menu/Dialogs/ColorMultipleSlugcatsDialog.cs
+++ b/Menu/Dialogs/ColorMultipleSlugcatsDialog.cs
@@ -1,0 +1,87 @@
+﻿using Menu;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RWCustom;
+using UnityEngine;
+
+namespace RainMeadow
+{
+    /// <summary>
+    /// Based on ColorSlugcatDialog, but adds support multiple slugcats. List of slugcats count shouldnt be 0
+    /// </summary>
+    public class ColorMultipleSlugcatsDialog : ColorSlugcatDialog
+    {
+        public bool SlugcatPagesOn => selectableSlugcats.Count > 1;
+        public ColorMultipleSlugcatsDialog(ProcessManager manager, Action onOK, List<SlugcatStats.Name> colorableSlugcats, int slugcatIndex = -1) : this(manager, onOK, colorableSlugcats, colorableSlugcats[Mathf.Max(slugcatIndex, 0)]) { }
+        public ColorMultipleSlugcatsDialog(ProcessManager manager, Action onOK, List<SlugcatStats.Name> colorableSlugcats, SlugcatStats.Name? slugcat) : base(manager, slugcat ?? colorableSlugcats[0], onOK)
+        {
+            selectableSlugcats = colorableSlugcats;
+            if (slugcat != null && !selectableSlugcats.Contains(slugcat))
+            {
+                RainMeadow.Debug("slugcat choosen first isnt part of the slugcat list? adding it if it was unintended. be warned for your original list used for the parameter");
+                selectableSlugcats.Insert(0, slugcat);
+            }
+            if (SlugcatPagesOn) ActivateSlugcatButtons();
+        }
+        public override void GrafUpdate(float timeStacker)
+        {
+            base.GrafUpdate(timeStacker);
+            if (slugcatPageStater != null)
+            {
+                slugcatPageStater.text = Translate(SlugcatStats.getSlugcatName(id));
+                slugcatPageStater.label.color = MenuColorEffect.rgbMediumGrey;
+            }
+        }
+        public void GotoNextPrevSlugcat(bool next)
+        {
+            PlaySound(SoundID.MENU_Button_Standard_Button_Pressed);
+            int currentIndex = selectableSlugcats.IndexOf(id);
+            int nextIndex = next ? (currentIndex + 1 >= selectableSlugcats.Count ? 0 : currentIndex + 1) : 
+                (currentIndex - 1 < 0 ? selectableSlugcats.Count - 1 : currentIndex - 1);
+            ChangeSlugcat(nextIndex);
+        }
+        public void ChangeSlugcat(int index)
+        {
+            RemoveColorButtons();
+            id = selectableSlugcats[index];
+            GetSaveColorEnabled();
+        }
+        public void ActivateSlugcatButtons()
+        {
+            if (prevSlugcatButton == null)
+            {
+                prevSlugcatButton = new(this, pages[0], "Menu_Symbol_Arrow", $"Prev{NextPrevSingal}", new(pos.x + size.x * 0.75f + 5, okButton.pos.y + 3));
+                prevSlugcatButton.OnClick += _ => GotoNextPrevSlugcat(false);
+                prevSlugcatButton.symbolSprite.rotation = 270;
+                pages[0].subObjects.Add(prevSlugcatButton);
+            }
+            if (nextSlugcatButton == null)
+            {
+                nextSlugcatButton = new(this, pages[0], "Menu_Symbol_Arrow", $"Next{NextPrevSingal}", new(prevSlugcatButton.pos.x + prevSlugcatButton.size.x + 10, prevSlugcatButton.pos.y));
+                nextSlugcatButton.OnClick += _ => GotoNextPrevSlugcat(true);
+                nextSlugcatButton.symbolSprite.rotation = 90;
+                pages[0].subObjects.Add(nextSlugcatButton);
+            }
+            if (slugcatPageStater == null)
+            {
+                slugcatPageStater = new(this, pages[0], "", new(prevSlugcatButton.pos.x + ((nextSlugcatButton.pos.x - prevSlugcatButton.pos.x + prevSlugcatButton.size.x) / 2) - 40, nextSlugcatButton.pos.y  + nextSlugcatButton.size.y + 10), new(80, 30), true);
+                pages[0].subObjects.Add(slugcatPageStater);
+            }
+            MutualHorizontalButtonBind(prevSlugcatButton, nextSlugcatButton);
+            MutualHorizontalButtonBind(okButton, prevSlugcatButton);
+        }
+        public void DeactivateSlugcatButtons()
+        {
+            pages[0].ClearMenuObject(ref prevSlugcatButton);
+            pages[0].ClearMenuObject(ref nextSlugcatButton);
+            pages[0].ClearMenuObject(ref slugcatPageStater);
+        }
+        public const string NextPrevSingal = "PageSlugcat_COLORMULTIPLESLUGCATS";
+        public List<SlugcatStats.Name> selectableSlugcats;
+        public MenuLabel? slugcatPageStater;
+        public SimplerSymbolButton? prevSlugcatButton, nextSlugcatButton;
+    }
+}

--- a/Menu/Dialogs/ColorSlugcatDialog.cs
+++ b/Menu/Dialogs/ColorSlugcatDialog.cs
@@ -22,7 +22,7 @@ namespace RainMeadow
             colorChooser = -1;
             colorCheckbox = new(this, pages[0], this, new(size.x + 40, size.y + -40 * 5), 0, "", COLORCHECKBOXID);
             pages[0].subObjects.Add(colorCheckbox);
-            this.TryMutualBind(colorCheckbox, okButton, true);
+            MutualHorizontalButtonBind(colorCheckbox, okButton);
             GetSaveColorEnabled();
         }
         public override void ShutDownProcess()
@@ -83,8 +83,7 @@ namespace RainMeadow
             SetUpSafeColorChoices();
             if (!manager.rainWorld.progression.miscProgressionData.colorsEnabled.ContainsKey(id.value))
             {
-                manager.rainWorld.progression.miscProgressionData.colorsEnabled.Add(id.value, colorChecked);
-                return;
+                manager.rainWorld.progression.miscProgressionData.colorsEnabled.Add(id.value, false);
             }
             colorCheckbox.Checked = manager.rainWorld.progression.miscProgressionData.colorsEnabled[id.value];
 
@@ -158,8 +157,11 @@ namespace RainMeadow
                 pages[0].subObjects.Add(defaultColor);
             }
             this.TryMutualBind(hueSlider, bodyInterface?.bodyButtons?.FirstOrDefault(), bottomTop: true);
+            MutualVerticalButtonBind(satSlider, hueSlider);
+            MutualVerticalButtonBind(litSlider, satSlider);
+            MutualVerticalButtonBind(defaultColor, litSlider);
             MutualVerticalButtonBind(colorCheckbox, defaultColor);
-            this.TryMutualBind(okButton, defaultColor);
+
         }
         public void RemoveColorButtons()
         {

--- a/Menu/Objects/ColorSlugcatBodyButtons.cs
+++ b/Menu/Objects/ColorSlugcatBodyButtons.cs
@@ -15,7 +15,7 @@ namespace RainMeadow
     public class ColorSlugcatBodyButtons : PositionedMenuObject
     {
         public int PerPage { get => perPage; set => perPage = Mathf.Max(1, value); }
-        public int CurrentOffset { get => currentOffset; set => currentOffset = Mathf.Clamp(value, 0, (bodyNames?.Count > 0) ? (bodyNames.Count - 1 / PerPage) : 0); }
+        public int CurrentOffset { get => currentOffset; set => currentOffset = Mathf.Clamp(value, 0, (bodyNames?.Count > 0) ? ((bodyNames.Count - 1) / PerPage) : 0); }
         public bool PagesOn => bodyNames?.Count > PerPage;
         public ColorSlugcatBodyButtons(Menu.Menu menu, MenuObject owner, Vector2 pos, SlugcatStats.Name slugcatID, List<string> names, List<string> defaultColors) : base(menu, owner, pos)
         {


### PR DESCRIPTION
meant to be more of a support to allow players to adjust their slugcat colors while playing as random slugcat (for random slugcat pr) however this can be treated more of an enhancement

- [x] tested for going to the current slugcat ur playing as at first when opening