### PR TITLE
Fixes to Current Level Selector

### DIFF
--- a/Menu/Components/ArenaLevelSelector.cs
+++ b/Menu/Components/ArenaLevelSelector.cs
@@ -14,6 +14,7 @@ namespace RainMeadow.UI.Components;
 
 public class ArenaLevelSelector : PositionedMenuObject
 {
+    //holy shit wtf is this
     public class LevelItem : ButtonTemplate, ButtonScroller.IPartOfButtonScroller, IHaveADescription
     {
         public MenuLabel label;
@@ -409,9 +410,7 @@ public class ArenaLevelSelector : PositionedMenuObject
 
         thumbLoadDelay = 2;
     }
-
     public bool IsThumbnailLoaded(string levelName) => loadedThumbTextures.Contains(levelName);
-
     public override void Update()
     {
         base.Update();


### PR DESCRIPTION
List of missing features/bugs to fix:
- [] Missing level preview
- [] Missing Add/Remove level animation and animation queue
- [] LevelItems are not clickable by mouse when in name mode
- [] When LevelItems in name mode are selected (via keyboard/controller and possibly mouse) their labels do not start blinking
- [] When LevelItems are in thumb mode and not selected, their labels are too dark
- [] Divider shows for the bottommost LevelItem when instead of being hidden and hides itself when it is second from the top instead of only vanishing when its LevelItem fades out the top
- [] When transitioning from thumb mode to name mode and back, the dividers and roundRects are not properly positioned relative to the label and thumbnail image (possibly too low?)
- [] Make Player Display inherit from VerticalScrollSelector 
- [] Prehaps make VerticalScrollSelector unify with ButtonScroller