### PR TITLE
6fears7 safe hostmigration

### DIFF
--- a/Arena/ArenaHooks.cs
+++ b/Arena/ArenaHooks.cs
@@ -1847,6 +1847,12 @@ namespace RainMeadow
 
             if (isArenaMode(out var arena))
             {
+                if (arena.currentLobbyOwner != OnlineManager.lobby.owner)
+                {
+                    self.game.manager.RequestMainProcessSwitch(ProcessManager.ProcessID.MultiplayerResults);
+                    arena.currentLobbyOwner = OnlineManager.lobby.owner;
+
+                }
                 if (self.Players.Count != arena.arenaSittingOnlineOrder.Count)
                 {
                     RainMeadow.Error($"Arena: Abstract Creature count does not equal registered players in the online Sitting! AC Count: {self.Players.Count} | ArenaSittingOnline Count: {arena.arenaSittingOnlineOrder.Count}");

--- a/GameModes/ArenaCompetitiveGameMode.cs
+++ b/GameModes/ArenaCompetitiveGameMode.cs
@@ -15,6 +15,8 @@ namespace RainMeadow
         public string currentGameMode;
         public Dictionary<ExternalArenaGameMode, string> registeredGameModes;
 
+        public OnlinePlayer currentLobbyOwner;
+
         public bool registeredNewGameModes = false;
 
         public bool isInGame;

--- a/Menu/ArenaOnlineLobbyMenu.cs
+++ b/Menu/ArenaOnlineLobbyMenu.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.EnterpriseServices.CompensatingResourceManager;
 using System.Linq;
 using System.Linq.Expressions;
 using Menu;

--- a/Menu/ArenaOnlineLobbyMenu.cs
+++ b/Menu/ArenaOnlineLobbyMenu.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.EnterpriseServices.CompensatingResourceManager;
 using System.Linq;
 using System.Linq.Expressions;
 using Menu;
@@ -39,6 +40,7 @@ public class ArenaOnlineLobbyMenu : SmartMenu
         RainMeadow.DebugMe();
         if (OnlineManager.lobby == null)
             throw new InvalidOperationException("lobby is null");
+        Arena.currentLobbyOwner = OnlineManager.lobby.owner;
         backTarget = RainMeadow.Ext_ProcessID.LobbySelectMenu;
         forceFlatIllu = !manager.rainWorld.flatIllustrations;
         if (backObject is SimplerButton btn) btn.description = Translate("Exit to Lobby Select");
@@ -165,7 +167,7 @@ public class ArenaOnlineLobbyMenu : SmartMenu
     {
         if (OnlineManager.lobby == null || !OnlineManager.lobby.isActive) return;
 
-        if (Arena.lobbyCountDown > 0)
+        if (OnlineManager.lobby.isOwner && Arena.lobbyCountDown > 0)
         {
             Arena.initiateLobbyCountdown = true;
             return;
@@ -183,6 +185,7 @@ public class ArenaOnlineLobbyMenu : SmartMenu
         PlaySound(SoundID.MENU_Start_New_Game);
         manager.RequestMainProcessSwitch(ProcessManager.ProcessID.Game);
         Arena.arenaClientSettings.ready = false;
+        
     }
     public void SetPlaylistFromSetupToSitting()
     {
@@ -267,6 +270,12 @@ public class ArenaOnlineLobbyMenu : SmartMenu
         if (pagesMoving) UpdateMovingPage();
         UpdateOnlineUI();
         UpdateElementBindings();
+
+        if (Arena.currentLobbyOwner != OnlineManager.lobby.owner)
+        {
+            ArenaHelpers.ResetOnReturnMenu(Arena, manager);
+            Arena.currentLobbyOwner = OnlineManager.lobby.owner;
+        }
 
         if (OnlineManager.lobby.isOwner)
         {


### PR DESCRIPTION
- End game session early if host migration occurs
- Mirror "return to lobby" functionality if a host changes while we're in the lobby. 

This should ensure everyone's back on the same page if a host migration occurs. 