### PR TITLE
feat: show ingame class

### DIFF
--- a/Arena/ArenaOnlineGameModes/BaseGameMode.cs
+++ b/Arena/ArenaOnlineGameModes/BaseGameMode.cs
@@ -360,12 +360,12 @@ namespace RainMeadow
                 if (overlayHUD.chatHud is null) overlayHUD.AddChatHUD(session.game.cameras[0]);
                 else overlayHUD.SetNewChatHUDCamera(session.game.cameras[0]);
             }
-                
+
 
             self.AddPart(new SpectatorHud(self, session.game.cameras[0]));
             self.AddPart(new ArenaPrepTimer(self, self.fContainers[0], arena, session));
             self.AddPart(new OnlineHUD(self, session.game.cameras[0], arena));
-            
+
             self.AddPart(new ArenaSpawnLocationIndicator(self, session.game.cameras[0]));
 
             if (OnlineManager
@@ -373,18 +373,18 @@ namespace RainMeadow
                     .GetData<ArenaClientSettings>()
                     .playingAs == RainMeadow.Ext_SlugcatStatsName.OnlineOverseerSpectator && arena.enableOverseer)
             {
-                
-                self.AddPart(new MeadowEmoteHud(self, session.game.cameras[0], 
+
+                self.AddPart(new MeadowEmoteHud(self, session.game.cameras[0],
                     arena.avatars.First(x => x.abstractCreature.creatureTemplate.type == CreatureTemplate.Type.Overseer).realizedCreature));
             }
             else
             {
                 self.AddPart(new Pointing(self));
-                foreach(AbstractCreature localPlayer in session.Players.Where(x => x != null && x.IsLocal()).ToArray())
+                foreach (AbstractCreature localPlayer in session.Players.Where(x => x != null && x.IsLocal()).ToArray())
                 {
                     var psmh = new HUD.PlayerSpecificMultiplayerHud(self, session, localPlayer)
                     {
-                        cornerPos = new Vector2(self.rainWorld.options.ScreenSize.x - self.rainWorld.options.SafeScreenOffset.x, 
+                        cornerPos = new Vector2(self.rainWorld.options.ScreenSize.x - self.rainWorld.options.SafeScreenOffset.x,
                                     20f + self.rainWorld.options.SafeScreenOffset.y),
                         flip = -1
                     };
@@ -405,8 +405,8 @@ namespace RainMeadow
                         self.AddPart(new Watcher.CamoMeter(self, psmh, self.fContainers[1]));
                     }
                 }
-                
-            }   
+
+            }
         }
 
         public virtual void ArenaCreatureSpawner_SpawnCreatures(
@@ -466,7 +466,7 @@ namespace RainMeadow
             OnlinePlayer player
         )
         {
-            if (OnlineManager.lobby.clientSettings.TryGetValue(player, out var cs) 
+            if (OnlineManager.lobby.clientSettings.TryGetValue(player, out var cs)
                 && cs.chatUsernameColor is Color color)
             {
                 return color;
@@ -1439,7 +1439,7 @@ namespace RainMeadow
 
                     string key = kvp[0];
                     string val = kvp[1];
-                    
+
                     int index = savedSettings.FindIndex(x => x.settingNickname == key);
                     RainMeadow.Debug($"Reading setting {key}, found index {index}, read value is {val}");
                     if (index >= 0)
@@ -1466,7 +1466,7 @@ namespace RainMeadow
         public string settingNickname { get; } = settingNickname == "" ? settingID : settingNickname;
     }
 
-    public class ExternalArenaGameModeFieldSetting(string settingID, string settingNickname = "") 
+    public class ExternalArenaGameModeFieldSetting(string settingID, string settingNickname = "")
         : ExternalArenaGameModeSetting(settingID, settingNickname)
     {
         // For now, suppost simple values (with IConvertible) and list of simple values.
@@ -1486,8 +1486,8 @@ namespace RainMeadow
         }
         protected static object ParseOrDefaultSimpleType(object value, Type type)
         {
-            return TryParseSimpleType(value, type, out var result) && result is not null 
-                ? result 
+            return TryParseSimpleType(value, type, out var result) && result is not null
+                ? result
                 : Activator.CreateInstance(type);
         }
         protected const char SEPARATOR = ',';
@@ -1496,10 +1496,10 @@ namespace RainMeadow
             if (settingType.IsGenericType && typeof(IEnumerable).IsAssignableFrom(settingType))
             {
                 Type ListingType = settingType.GetGenericArguments()[0];
-                IEnumerable<object> elements = string.IsNullOrWhiteSpace(value) 
-                    ? [] 
+                IEnumerable<object> elements = string.IsNullOrWhiteSpace(value)
+                    ? []
                     : value.Split(SEPARATOR).Select(s => ParseOrDefaultSimpleType(s, ListingType));
-                
+
                 RainMeadow.Debug($"Found enumerable {settingType}:{ListingType}, converted values are {string.Join(",", elements)}");
                 if (settingType.GetGenericTypeDefinition() == typeof(List<>))
                 {
@@ -1544,10 +1544,10 @@ namespace RainMeadow
             }
             return settingField.GetValue(arenaMode).ToString();
         }
-        public FieldInfo settingField {get;} = typeof(ArenaOnlineGameMode).GetField(settingID);
-        public Type settingType {get;} = typeof(ArenaOnlineGameMode).GetField(settingID).FieldType;
+        public FieldInfo settingField { get; } = typeof(ArenaOnlineGameMode).GetField(settingID);
+        public Type settingType { get; } = typeof(ArenaOnlineGameMode).GetField(settingID).FieldType;
     }
-    public class ExternalArenaGameModeInterfaceMultiChoiceSetting(string settingID, string settingNickname = "") 
+    public class ExternalArenaGameModeInterfaceMultiChoiceSetting(string settingID, string settingNickname = "")
         : ExternalArenaGameModeSetting(settingID, settingNickname)
     {
         public override object GetValueFromArenaMode(ArenaOnlineGameMode arenaMode)

--- a/Arena/ArenaOnlineGameModes/Competitive.cs
+++ b/Arena/ArenaOnlineGameModes/Competitive.cs
@@ -136,7 +136,8 @@ namespace RainMeadow
             }
             else
             {
-                return "Kill_Slugcat";
+                // falls through to the slugcat class icon
+                return "";
             }
 
         }

--- a/Arena/ArenaOnlineGameModes/Drown/Drown.cs
+++ b/Arena/ArenaOnlineGameModes/Drown/Drown.cs
@@ -251,7 +251,8 @@ namespace RainMeadow
                     }
                     else
                     {
-                        return "Kill_Slugcat";
+                        // falls through to the slugcat class icon
+                        return "";
 
                     }
                 }

--- a/Menu/Components/SlugIcon.cs
+++ b/Menu/Components/SlugIcon.cs
@@ -51,6 +51,71 @@ public class SlugIcon : PositionedMenuObject
             { "Watcher", ["17234F", "FFFFFF"] },
         };
 
+    public const string AtlasPath = "illustrations/slugicons";
+
+    /// <summary>
+    /// Used to check if the icon is loaded.
+    /// </summary>
+    private const string AtlasProbeElement = "basic_head";
+
+    private static readonly List<string> FallbackSpriteNames =
+    [
+        "basic_head",
+        "basic_face",
+        "modded_feature",
+    ];
+    private static readonly List<string?> FallbackHexColors = ["FFFFFF", "101010", "FFFFFF"];
+
+    public static void LoadAtlas()
+    {
+        if (!Futile.atlasManager.DoesContainElementWithName(AtlasProbeElement))
+            Futile.atlasManager.LoadAtlas(AtlasPath);
+    }
+
+    public static List<string> GetSpriteNames(string slugcat, bool dead = false)
+    {
+        List<string> spriteNames = SlugcatToSpriteNames.TryGetValue(slugcat, out List<string> names)
+            ? [.. names]
+            : [.. FallbackSpriteNames];
+
+        if (dead)
+        {
+            int faceIndex = spriteNames.FindIndex(name => name.EndsWith("_face"));
+            if (faceIndex >= 0)
+                spriteNames[faceIndex] = "dead_face";
+        }
+
+        return spriteNames;
+    }
+
+    public static List<Color> GetColors(string slugcat, List<Color>? colors)
+    {
+        if (colors != null && colors.Count >= 2)
+            return colors;
+
+        if (!SlugcatToDefaultColors.TryGetValue(slugcat, out List<string?> hexColors))
+        {
+            RainMeadow.Error(
+                "Not enough colors provided to SlugIcon and no default colours were found for the given slugcat, using fallback colors"
+            );
+            hexColors = FallbackHexColors;
+        }
+
+        return [.. hexColors.Select(hex => Custom.hexToColor(hex ?? "FFFFFF"))];
+    }
+
+    /// <summary>
+    /// tints sprite with GetColors
+    /// </summary>
+    public static int ColorIndexForSprite(string spriteName) =>
+        spriteName.Split('_').Last() switch
+        {
+            "head" => 0,
+            "face" => 1,
+            "feature" => 2,
+            _ => -1,
+        };
+
     public List<PositionedSprite> sprites = [];
     public Dictionary<string, int> spriteLayerToColorIndex = [];
     public List<Color>? colors = [];
@@ -67,7 +132,7 @@ public class SlugIcon : PositionedMenuObject
     )
         : base(menu, owner, pos)
     {
-        Futile.atlasManager.LoadAtlas("illustrations/slugicons");
+        LoadAtlas();
 
         this.colors = colors;
 
@@ -92,21 +157,17 @@ public class SlugIcon : PositionedMenuObject
         if (slugcat == "")
             return;
 
-        List<string> spriteNames = SlugcatToSpriteNames.TryGetValue(slugcat, out List<string> names)
-            ? names
-            : ["basic_head", "basic_face", "modded_feature"];
-        if (dead)
-            spriteNames[spriteNames.FindIndex(name => name.EndsWith("_face"))] = "dead_face";
+        List<string> spriteNames = GetSpriteNames(slugcat, dead);
 
         for (int i = 0; i < spriteNames.Count; i++)
         {
             string spriteName = spriteNames[i];
             sprites.Add(new PositionedSprite(menu, this, Vector2.zero, new FSprite(spriteName)));
-            spriteLayerToColorIndex.Add(spriteName.Split('_').Last(), i);
+            spriteLayerToColorIndex[spriteName.Split('_').Last()] = i;
         }
 
         subObjects.AddRange([.. sprites]);
-        ApplyPalette();
+        ApplyPalette(this.colors);
     }
 
     public void ApplyPalette(List<Color>? newColors = null)
@@ -116,29 +177,13 @@ public class SlugIcon : PositionedMenuObject
         if (sprites.Count == 0)
             return;
 
-        List<Color> colors = this.colors ?? [];
+        List<Color> colors = GetColors(slugcat, this.colors);
 
-        if (colors.Count < 2)
+        foreach (KeyValuePair<string, int> layer in spriteLayerToColorIndex)
         {
-            if (!SlugcatToDefaultColors.TryGetValue(slugcat, out List<string?> hexColors))
-            {
-                RainMeadow.Debug(
-                    "Not enough colours were provided to SlugIcon and no default colours were found for the given slugcat, using fallback colours"
-                );
-                hexColors = ["FFFFFF", "101010", "FFFFFF"];
-            }
-            colors = [.. hexColors.Select(hex => Custom.hexToColor(hex ?? "FFFFFF"))];
+            int colorIndex = ColorIndexForSprite(layer.Key);
+            if (colorIndex >= 0 && colorIndex < colors.Count)
+                sprites[layer.Value].Sprite.color = colors[colorIndex];
         }
-
-        void TryMapColorsToSprites(string spritePart, Color color)
-        {
-            if (spriteLayerToColorIndex.TryGetValue(spritePart, out int index))
-                sprites[index].Sprite.color = color;
-        }
-
-        TryMapColorsToSprites("head", colors[0]);
-        TryMapColorsToSprites("face", colors[1]);
-        if (colors.Count > 2)
-            TryMapColorsToSprites("feature", colors[2]);
     }
 }

--- a/OnlineUIComponents/OnlinePlayerDisplay.cs
+++ b/OnlineUIComponents/OnlinePlayerDisplay.cs
@@ -14,7 +14,7 @@ namespace RainMeadow
         public List<FLabel> messageLabels = new();
         public FLabel pingLabel;
         public FLabel? scoreLabel;
-        public FSprite slugIcon;
+        public SlugcatClassIconHud slugIcon;
         public OnlinePlayer player;
         public class Message
         {
@@ -113,7 +113,8 @@ namespace RainMeadow
                 }
                 else
                 {
-                    this.iconString = "Kill_Slugcat";
+                    // "" falls through to the slugcat class icon instead of referencing stuff in-game
+                    this.iconString = "";
                 }
 
 
@@ -139,13 +140,16 @@ namespace RainMeadow
                 }
             }
 
-            this.slugIcon = new FSprite(iconString, true);
-            owner.hud.fContainers[0].AddChild(this.slugIcon);
-            this.slugIcon.alpha = 0f;
-            this.slugIcon.x = -1000f;
+            this.slugIcon = new SlugcatClassIconHud(owner.hud.fContainers[0]);
+            if (iconString != "")
+            {
+                this.slugIcon.SetElement(iconString, lighter_color);
+            }
+            else
+            {
+                this.slugIcon.SetSlugcat(SlugcatName(customization), false, customization.currentColors);
+            }
 
-
-            this.slugIcon.color = lighter_color;
             this.blink = 1f;
 
             this.username = new FLabel(Custom.GetFont(), UsernameGenerator.StreamerModeName(customization.nickname));
@@ -231,34 +235,29 @@ namespace RainMeadow
 
                     if (owner.PlayerConsideredDead) this.alpha = Mathf.Min(this.alpha, 0.5f);
 
-                    if (onlineTimeSinceSpawn < 135 && owner.clientSettings.isMine)
-                    {
-                        slugIcon.SetElementByName("Kill_Slugcat");
-                    }
+                    // An empty element means no special-case icon applies, so the player's
+                    // slugcat class icon is drawn instead.
+                    string element;
+                    Color elementColor = lighter_color;
+                    bool dead = owner.PlayerConsideredDead;
+
+                    if (onlineTimeSinceSpawn < 135 && owner.clientSettings.isMine) element = "";
                     else if (RainMeadow.isArenaMode(out var arena))
                     {
-                        if (arena.externalArenaGameMode.AddIcon(arena, this, owner, customization, player) != "")
-                        {
-                            slugIcon.SetElementByName(arena.externalArenaGameMode.AddIcon(arena, this, owner, customization, player));
-                        }
-                        else if (owner.PlayerConsideredDead) slugIcon.SetElementByName("Multiplayer_Death");
-                        slugIcon.color = arena.externalArenaGameMode.IconColor(arena, this, owner, customization, player);
+                        element = arena.externalArenaGameMode.AddIcon(arena, this, owner, customization, player);
+                        elementColor = arena.externalArenaGameMode.IconColor(arena, this, owner, customization, player);
+                    }
+                    else if (owner.PlayerInAncientShelter) element = "ShortcutAShelter";
+                    else if (owner.PlayerInShelter) element = "ShortcutShelter";
+                    else if (owner.PlayerInGate) element = "ShortcutGate";
+                    // use the new dead icon vs the old "Multiplayer_Death" sprite.
+                    else if (dead) element = "";
+                    else element = iconString;
 
-                    }
-                    else if (owner.PlayerInAncientShelter) slugIcon.SetElementByName("ShortcutAShelter");
-                    else if (owner.PlayerInShelter) slugIcon.SetElementByName("ShortcutShelter");
-                    else if (owner.PlayerInGate) slugIcon.SetElementByName("ShortcutGate");
-                    else if (owner.PlayerConsideredDead) slugIcon.SetElementByName("Multiplayer_Death");
+                    if (element != "") slugIcon.SetElement(element, elementColor);
+                    else slugIcon.SetSlugcat(SlugcatName(customization), dead, customization.currentColors);
 
-                    else slugIcon.SetElementByName(iconString);
-                    if (slugIcon.element.name == "meadowcoin")
-                    {
-                        this.slugIcon.scale = 0.08f;
-                    }
-                    else
-                    {
-                        this.slugIcon.scale = 1f;
-                    }
+                    this.slugIcon.scale = slugIcon.ElementName == "meadowcoin" ? 0.08f : 1f;
 
                     if (flashIcons) this.alpha = Mathf.Lerp(lighter_color.a, 0f, (Mathf.Cos(owner.owner.hudCounter / fadeSpeed) + 1f) / 2f);
                     else if (RainMeadow.rainMeadowOptions.ShowFriends.Value) this.alpha = lighter_color.a;
@@ -410,7 +409,7 @@ namespace RainMeadow
             }
 
             this.arrowSprite.alpha = num;
-            this.slugIcon.alpha = num;
+            this.slugIcon.Alpha = num;
             if (this.messageQueue.Count > 0 && (flashIcons || RainMeadow.rainMeadowOptions.ShowFriends.Value))
             {
                 this.username.alpha = lighter_color.a;
@@ -432,6 +431,11 @@ namespace RainMeadow
                     color = Color.Lerp(color, new Color(1f, 1f, 1f), Mathf.InverseLerp(0f, 0.5f, Mathf.Lerp(this.lastBlink, this.blink, timeStacker)));
                 }
             }
+        }
+
+        public static string SlugcatName(SlugcatCustomization customization)
+        {
+            return customization.playingAs?.value ?? "";
         }
 
         public string SetTypingUsername()

--- a/OnlineUIComponents/SlugcatClassIconHud.cs
+++ b/OnlineUIComponents/SlugcatClassIconHud.cs
@@ -1,0 +1,157 @@
+using System.Collections.Generic;
+using RainMeadow.UI.Components;
+using UnityEngine;
+
+namespace RainMeadow
+{
+    /// <summary>
+    /// The HUD addition to <see cref="SlugIcon"/>. Draws either a single atlas element (Kill_Slugcat, for ex.) or a
+    /// layered slugcat class icon (like the beautiful sluggy icons for the lobby), sharing <see cref="SlugIcon"/>'s sprite and color maps.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="SlugIcon"/> itself is a <c>PositionedMenuObject</c> and so needs a menu to live
+    /// in. Plain <see cref="FSprite"/>s in a container of
+    /// its own instead so it can be managed as one icon. Thank you @Timbits & @None
+    /// </remarks>
+    public class SlugcatClassIconHud
+    {
+        /// <summary>If any atlses are missing, fallback to ye ol faithful</summary>
+        private const string MissingElementFallback = "Kill_Slugcat";
+
+        public FContainer container = new();
+        public List<FSprite> sprites = [];
+
+        private List<string> spriteNames = [];
+        private string element = "";
+        private string slugcat = "";
+        private bool dead;
+
+        public string ElementName => element;
+
+        public float x
+        {
+            get => container.x;
+            set => container.x = value;
+        }
+        public float y
+        {
+            get => container.y;
+            set => container.y = value;
+        }
+        public float Alpha
+        {
+            get => container.alpha;
+            set => container.alpha = value;
+        }
+        public float scale
+        {
+            get => container.scale;
+            set => container.scale = value;
+        }
+
+        public SlugcatClassIconHud(FContainer parent)
+        {
+            parent.AddChild(container);
+            container.alpha = 0f;
+            container.x = -1000f;
+        }
+
+        /// <summary>Draw a single atlas element (tinted) <paramref name="color"/>.</summary>
+        public void SetElement(string elementName, Color color)
+        {
+            if (element != elementName)
+            {
+                element = elementName;
+                slugcat = "";
+                Rebuild();
+            }
+
+            for (int i = 0; i < sprites.Count; i++)
+                sprites[i].color = color;
+        }
+
+        /// <summary>
+        /// Draw <paramref name="slugcatName"/>'s layered class icon, colored by
+        /// <paramref name="colors"/> (head, face, and optional features).
+        /// </summary>
+        public void SetSlugcat(string slugcatName, bool dead, List<Color>? colors)
+        {
+            if (element != "" || slugcat != slugcatName || this.dead != dead)
+            {
+                element = "";
+                slugcat = slugcatName;
+                this.dead = dead;
+                Rebuild();
+            }
+
+            ApplyPalette(colors);
+        }
+
+        public void RemoveFromContainer()
+        {
+            ClearSprites();
+            container.RemoveFromContainer();
+        }
+
+        private void ClearSprites()
+        {
+            for (int i = 0; i < sprites.Count; i++)
+                sprites[i].RemoveFromContainer();
+            sprites = [];
+            spriteNames = [];
+        }
+
+        private void Rebuild()
+        {
+            ClearSprites();
+
+            if (element != "")
+            {
+                AddSprite(element);
+                return;
+            }
+
+            if (slugcat == "")
+                return;
+
+            SlugIcon.LoadAtlas();
+            foreach (string spriteName in SlugIcon.GetSpriteNames(slugcat, dead))
+                AddSprite(spriteName, skipIfMissing: true);
+
+            // fallback for modded scugs
+            if (sprites.Count == 0)
+                AddSprite(MissingElementFallback);
+        }
+
+        private void AddSprite(string spriteName, bool skipIfMissing = false)
+        {
+            if (!Futile.atlasManager.DoesContainElementWithName(spriteName))
+            {
+                if (skipIfMissing)
+                    return;
+                RainMeadow.Error($"SlugcatClassIconHud: no atlas element named {spriteName}");
+                spriteName = MissingElementFallback;
+            }
+
+            FSprite sprite = new(spriteName, true);
+            container.AddChild(sprite);
+            sprites.Add(sprite);
+            spriteNames.Add(spriteName);
+        }
+
+        private void ApplyPalette(List<Color>? newColors)
+        {
+            if (sprites.Count == 0)
+                return;
+
+            List<Color> colors = SlugIcon.GetColors(slugcat, newColors);
+
+            for (int i = 0; i < sprites.Count; i++)
+            {
+                int colorIndex = SlugIcon.ColorIndexForSprite(spriteNames[i]);
+                sprites[i].color =
+                    colorIndex >= 0 && colorIndex < colors.Count ? colors[colorIndex] : Color.white;
+            }
+        }
+    }
+}


### PR DESCRIPTION
@T1mbits I dont actually want to merge this into your branch, it's just to show you the diff while waiting for the menu stuff to be resolved. 

It adds:
- Arena game mode icon update so that empty string really just triggers the use of the SlugclassIcon
- Static functions in SlugIcon to use in SlugClassIconHud
- SlugClassIconHud

Here's how it looks ingame, minus a player arrow point issue not related to this:

<img width="2568" height="789" alt="image" src="https://github.com/user-attachments/assets/038cc111-355d-4138-8343-2f9eb5ce94fd" />

didn't know if you had any opinions on this based on the changes you had just made to SlugIcon

- [ ] Needs to tested with wingcat
- [ ] And other general scenarios   